### PR TITLE
Round currency ticks to the hundredths place.

### DIFF
--- a/profbit/static/js/stats.js
+++ b/profbit/static/js/stats.js
@@ -89,7 +89,7 @@ function getChartConfig(graphData) {
           ticks: {
             // Include a currency sign in the ticks
             callback: function(value, index, values) {
-              return window.profbitContext.nativeCurrencySymbol + value.toFixed(2);
+              return formatCurrency(value);
             },
           },
         }]

--- a/profbit/static/js/stats.js
+++ b/profbit/static/js/stats.js
@@ -2,7 +2,7 @@ function formatPercent(value) {
   return value.toFixed(2) + '%';
 }
 
-function formatCurrency(value, applyAbs) {
+function formatCurrency(value) {
   return window.profbitContext.currencyFormatter.format(value);
 }
 

--- a/profbit/static/js/stats.js
+++ b/profbit/static/js/stats.js
@@ -89,7 +89,7 @@ function getChartConfig(graphData) {
           ticks: {
             // Include a currency sign in the ticks
             callback: function(value, index, values) {
-              return window.profbitContext.nativeCurrencySymbol + value;
+              return window.profbitContext.nativeCurrencySymbol + value.toFixed(2);
             },
           },
         }]


### PR DESCRIPTION
Currency ticks are not rounded at the moment:

![screen shot 2017-11-27 at 4 43 52 pm](https://user-images.githubusercontent.com/824173/33291013-813c6812-d392-11e7-9781-b6e2d74eac4e.png)

Pretty sure this fixes it, although haven't stood up the app locally. Test and verify?